### PR TITLE
Remove awsutils-s3 dependency from 1.17-alpine images

### DIFF
--- a/1.17-alpine-v1/Dockerfile
+++ b/1.17-alpine-v1/Dockerfile
@@ -10,7 +10,7 @@ RUN apk update && apk add \
     python3
 
 # Install replace_domain & awsutils-s3
-RUN pip3 install --upgrade pip && pip3 install replace_domain>=1.0.5 awsutils-s3>=0.3.18
+RUN pip3 install --upgrade pip && pip3 install replace_domain>=1.0.5
 
 # Copy nginx configuration files & delete default
 RUN rm /etc/nginx/conf.d/default.conf

--- a/1.17-alpine-v2/Dockerfile
+++ b/1.17-alpine-v2/Dockerfile
@@ -10,7 +10,7 @@ RUN apk update && apk add \
     python3
 
 # Install replace_domain & awsutils-s3
-RUN pip3 install --upgrade pip && pip3 install replace_domain>=1.0.5 awsutils-s3>=0.3.18
+RUN pip3 install --upgrade pip && pip3 install replace_domain>=1.0.5
 
 # Copy nginx configuration files & delete default
 RUN rm /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
- cut awsutils-s3 installations from 1.17-alpine-v1 & 1.17-alpine-v2